### PR TITLE
fix: set the pending state correctly

### DIFF
--- a/app/composables/asyncOps.ts
+++ b/app/composables/asyncOps.ts
@@ -4,12 +4,12 @@
  * @returns The async ops and the last updated at timestamp.
  */
 export function useAsyncOps() {
-    const { isUpdateWatched, asyncOpsState, lastUpdatedAt } = state;
-    const pending = ref<boolean>(!isUpdateWatched);
-
-    if (!isUpdateWatched) {
-        // Async function to watch for updates.
-        watchForUpdates(pending);
+    const { isUpdatePending, asyncOpsState, lastUpdatedAt, isWatchStarted } =
+        state;
+    const pending = isUpdatePending;
+    // Async function to watch for updates.
+    if (!isWatchStarted) {
+        watchForUpdates();
     }
 
     return {

--- a/app/composables/resources.ts
+++ b/app/composables/resources.ts
@@ -3,12 +3,12 @@
  * @returns The resources data and the last updated time.
  */
 export function useResources() {
-    const { isUpdateWatched, resourceState, lastUpdatedAt } = state;
-    const pending = ref<boolean>(!isUpdateWatched);
-
-    if (isUpdateWatched) {
-        // Async function to watch for updates.
-        watchForUpdates(pending);
+    const { isUpdatePending, resourceState, lastUpdatedAt, isWatchStarted } =
+        state;
+    const pending = isUpdatePending;
+    // Async function to watch for updates.
+    if (!isWatchStarted) {
+        watchForUpdates();
     }
 
     return {

--- a/app/composables/state.ts
+++ b/app/composables/state.ts
@@ -601,7 +601,11 @@ export interface State {
     resourceState: ResourceState;
     asyncOpsState: AsyncOpState;
     lastUpdatedAt: Ref<Timestamp | undefined>;
-    isUpdateWatched: boolean;
+    // Tracks if the update stream is started.
+    // To avoid starting the update stream twice, we track if it's started.
+    isWatchStarted: boolean;
+    // Tracks if an update is pending from the async update stream.
+    isUpdatePending: Ref<boolean>;
 }
 
 export const state: State = {
@@ -611,7 +615,8 @@ export const state: State = {
     resourceState: new ResourceState(),
     asyncOpsState: new AsyncOpState(),
     lastUpdatedAt: ref<Timestamp | undefined>(undefined),
-    isUpdateWatched: false,
+    isWatchStarted: false,
+    isUpdatePending: ref(true),
 };
 
 export function initState() {

--- a/app/composables/tasks.ts
+++ b/app/composables/tasks.ts
@@ -13,19 +13,12 @@ import { TaskDetailsRequest } from "~/gen/instrument_pb";
  * state. It also starts a watch for updates if it hasn't already been started.
  */
 export function useTasks() {
-    const { isUpdateWatched, lastUpdatedAt, taskState } = state;
-
-    if (isUpdateWatched) {
-        return {
-            pending: ref<boolean>(false),
-            tasksData: taskState.tasks.items,
-            lastUpdatedAt,
-        };
-    }
-
-    const pending = ref<boolean>(true);
+    const { isUpdatePending, lastUpdatedAt, taskState, isWatchStarted } = state;
+    const pending = isUpdatePending;
     // Async function to watch for updates.
-    watchForUpdates(pending);
+    if (!isWatchStarted) {
+        watchForUpdates();
+    }
     return {
         pending,
         tasksData: taskState.tasks.items,


### PR DESCRIPTION
1. Use `isWatchStarted` to track whether we have already initiated the watch request.
2. Use `isUpdatePending` to keep track of whether the update stream is connected.