### PR TITLE
feat: print stout and stdin in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,9 @@ fn run_command(name: &str, dir: &str, args: &[&str]) -> Result<(), String> {
     } else {
         name
     };
+
+    println!("Running command: {} in directory: {} with arguments: {:?}", cmd, dir, args);
+
     let output = Command::new(cmd)
         .current_dir(dir)
         .args(args)
@@ -43,8 +46,11 @@ fn run_command(name: &str, dir: &str, args: &[&str]) -> Result<(), String> {
         .map_err(|e| format!("Failed to execute {}: {}", name, e))?;
 
     if !output.status.success() {
+        eprintln!("Command stderr: {}", String::from_utf8_lossy(&output.stderr));
         return Err(format!("Error: {} failed", name));
     }
+
+    println!("Command stdout: {}", String::from_utf8_lossy(&output.stdout));
     Ok(())
 }
 


### PR DESCRIPTION
It will help us to debug the building steps.
```console
Caused by:
  process didn't exit successfully: `/Volumes/t7/code/console-web/target/package/tokio-console-web-0.1.1-beta.2/target/debug/build/tokio-console-web-43191f3afa99ea37/build-script-build` (exit status: 1)
  --- stdout
  Running command: wasm-pack in directory: app with arguments: ["build", "histogram"]

  --- stderr
  Failed to execute wasm-pack: No such file or directory (os error 2)
warning: build failed, waiting for other jobs to finish...
error: failed to verify package tarball
```