### PR TITLE
ci: only create release-pr with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,6 +23,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["Rustin170506"]
 description = "A web console for tokio"
+include = ["src/main.rs", "app/.output/public"]
 edition = "2021"
 license = "MIT"
 name = "tokio-console-web"


### PR DESCRIPTION
This project is special because we cannot include app/output/public into the VCS. So we cannot use release-please to directly create the release. We have to create it manually.