### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 - (2024-09-09)
+
+
+### Ci
+
+- Only check diff on macos-latest ([#325](https://github.com/Rustin170506/tokio-console-web/pull/325)) ([5f2cac2](https://github.com/Rustin170506/tokio-console-web/commit/5f2cac2dcfb492bc89ce49d70b9c9f67a9537b31))
+
+
 ## 0.1.1 - (2024-09-02)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-console-web"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 name = "tokio-console-web"
 repository = "https://github.com/Rustin170506/tokio-console-web"
-version = "0.1.1"
+version = "0.1.2"
 
 [package.metadata.wix]
 eula = false


### PR DESCRIPTION
## 🤖 New release
* `tokio-console-web`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## 0.1.2 - (2024-09-09)

### Ci

- Only check diff on macos-latest ([#325](https://github.com/Rustin170506/tokio-console-web/pull/325)) ([5f2cac2](https://github.com/Rustin170506/tokio-console-web/commit/5f2cac2dcfb492bc89ce49d70b9c9f67a9537b31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).