### PR TITLE
chore: delete useless .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-.gitignore


### PR DESCRIPTION
Now that we don't have any dockerfiles, we can safely remove the `.dockerignore` file.